### PR TITLE
Mudança no retorno do plugin

### DIFF
--- a/includes/class-wc-mundipagg-api.php
+++ b/includes/class-wc-mundipagg-api.php
@@ -729,7 +729,7 @@ class WC_Mundipagg_API {
 
 			self::update_order_status( $data['reference'], $data['status'], $invoice_prefix );
 
-			die("OK");
+			die( 'OK' );
 		}
 	}
 }

--- a/includes/class-wc-mundipagg-api.php
+++ b/includes/class-wc-mundipagg-api.php
@@ -729,7 +729,7 @@ class WC_Mundipagg_API {
 
 			self::update_order_status( $data['reference'], $data['status'], $invoice_prefix );
 
-			exit;
+			die("OK");
 		}
 	}
 }


### PR DESCRIPTION
Segundo o suporte da MundiPagg, sem um OK explicito no body não há uma confirmação de que a notificação foi efetuada corretamente.